### PR TITLE
Update to support latest bazel rules_apple version.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,10 +16,6 @@ objc_library(
 objc_library(
     name = "MOLCertificateTestsLib",
     srcs = glob(["Tests/MOLCertificateTest.m"]),
-    data = glob([
-        "Tests/*.pem",
-        "Tests/*.crt",
-    ]),
     deps = [":MOLCertificate"],
 )
 
@@ -28,5 +24,10 @@ load("@build_bazel_rules_apple//apple:macos.bzl", "macos_unit_test")
 macos_unit_test(
     name = "MOLCertificateTests",
     minimum_os_version = "10.9",
+    resources = glob([
+        "Tests/*.pem",
+        "Tests/*.crt",
+    ]),
+
     deps = [":MOLCertificateTestsLib"],
 )

--- a/MOLCertificate.podspec
+++ b/MOLCertificate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'MOLCertificate'
-  s.version      = '2.1'
+  s.version      = '2.2'
   s.platform     = :osx, '10.9'
   s.license      = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage     = 'https://github.com/google/macops-molcertificate'

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.6.0",
+    tag = "0.31.3",
 )
 
 load(


### PR DESCRIPTION
This means moving test resources into macos_unit_test instead of
objc_library as that attribute has been removed from objc_library.

I noticed that MOLCodesignCheckerTest from https://github.com/google/macops-molcodesignchecker fails to build because of this. Sending a PR to fix that next too.